### PR TITLE
add defaultVisible option

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ keymap.cson
 | highlightFgColor   | --note-list-view-item-active-color      |
 | width              | 200                                     |
 | textwrap           | true                                    |
+| defaultVisible     | true                                    |
 
 config.cson
 
@@ -75,6 +76,7 @@ sidetoc:
   highlightFgColor: "black"
   width: 200
   textwrap: false
+  defaultVisible: true
 ```
 
 Settings UI

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -10,6 +10,7 @@ var Settings = /** @class */ (function () {
         this.currentWidth = 0;
         this._settingWidth = 0;
         this.isTextwrap = true;
+        this.isDefaultVisible = true;
         this.sidetocPanePadding = 10;
         /*
          *
@@ -67,6 +68,13 @@ var Settings = /** @class */ (function () {
                 newValue = true;
             }
             _this.isTextwrap = newValue;
+        });
+        // visibility
+        inkdrop.config.observe("sidetoc.defaultVisible", function (newValue) {
+            if (newValue == undefined) {
+                newValue = true;
+            }
+            _this.isDefaultVisible = newValue;
         });
         // wrapper's padding
         document.documentElement.style.setProperty("--inkdrop-sidetoc-padding", this.sidetocPanePadding.toString(10) + "px");

--- a/lib/sidetoc-pane.js
+++ b/lib/sidetoc-pane.js
@@ -323,7 +323,7 @@ var SideTocPane = /** @class */ (function (_super) {
         var _this = this;
         // state of this component
         this.state = {
-            visibility: true,
+            visibility: Settings.isDefaultVisible,
             headers: [],
             currentHeader: null,
             min: 0,

--- a/lib/sidetoc.js
+++ b/lib/sidetoc.js
@@ -72,6 +72,11 @@ module.exports = {
             type: "boolean",
             default: true,
         },
+        defaultVisible: {
+            title: "show sidetoc by default",
+            type: "boolean",
+            default: true,
+        },
     },
     activate: function () {
         plugin.activate();

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -12,6 +12,7 @@ class Settings {
   currentWidth: number = 0;
   _settingWidth: number = 0;
   isTextwrap: boolean = true;
+  isDefaultVisible: boolean = true;
   sidetocPanePadding = 10;
   computedStyle: CSSStyleDeclaration;
 
@@ -45,6 +46,13 @@ class Settings {
         newValue = true;
       }
       this.isTextwrap = newValue;
+    });
+    // visibility
+    inkdrop.config.observe("sidetoc.defaultVisible", (newValue: boolean) => {
+      if (newValue == undefined) {
+        newValue = true;
+      }
+      this.isDefaultVisible = newValue;
     });
     // wrapper's padding
     document.documentElement.style.setProperty(

--- a/src/sidetoc-pane.tsx
+++ b/src/sidetoc-pane.tsx
@@ -31,7 +31,7 @@ export default class SideTocPane extends React.Component<Props, State> {
   componentWillMount() {
     // state of this component
     this.state = {
-      visibility: true,
+      visibility: Settings.isDefaultVisible,
       headers: [],
       currentHeader: null,
       min: 0,

--- a/src/sidetoc.ts
+++ b/src/sidetoc.ts
@@ -85,6 +85,11 @@ module.exports = {
       type: "boolean",
       default: true,
     },
+    defaultVisible: {
+      title: "show sidetoc by default",
+      type: "boolean",
+      default: true,
+    },
   },
   activate() {
     plugin.activate();


### PR DESCRIPTION
Hi, 

Thank you for nice plugin.
I'm loving to use this when I write/reading long texts.

But when on short ones (or starting a new text), I think this plugin could be obstacle because it narrows the editing pane.
And I write short texts mostly 🙁

I thought it is a good idea to make the default visibility of this plugin to be an option so I wrote a patch.

Could you please review this and consider merging if you liked it.
Thanks 🙂
